### PR TITLE
[LA.UM.8.1.r1] Cherry-pick gralloc1 separation from 7.1

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,5 +1,26 @@
+bootstrap_go_package {
+    name: "soong-gralloc_defaults",
+    pkgPath: "vendor/qcom/opensource/display-commonsys-intf",
+    deps: [
+        "blueprint",
+        "blueprint-pathtools",
+        "soong",
+        "soong-android",
+        "soong-cc",
+    ],
+    srcs: [
+        "gralloc_defaults.go",
+    ],
+    pluginFor: ["soong_build"],
+}
+
+gralloc_defaults {
+    name: "gralloc_defaults",
+}
+
 cc_library_headers {
     name: "display_intf_headers",
+    defaults: ["gralloc_defaults"],
     vendor_available: true,
     export_include_dirs: [
         "gralloc",

--- a/gralloc-next/private_handle_members.h
+++ b/gralloc-next/private_handle_members.h
@@ -1,0 +1,46 @@
+  unsigned int layer_count;
+  uint64_t id;
+  uint64_t usage;
+
+  unsigned int size;
+  unsigned int offset;
+  unsigned int offset_metadata;
+  uint64_t base;
+  uint64_t base_metadata;
+  uint64_t gpuaddr;
+
+#ifdef __cplusplus
+  static const int kNumFds = 2;
+  static const int kMagic = 'gmsm';
+
+  static inline int NumInts() {
+    return ((sizeof(private_handle_t) - sizeof(native_handle_t)) / sizeof(int)) - kNumFds;
+  }
+
+  private_handle_t(int fd, int meta_fd, int flags, int width, int height, int uw, int uh,
+                   int format, int buf_type, unsigned int size, uint64_t usage = 0)
+      : fd(fd),
+        fd_metadata(meta_fd),
+        magic(kMagic),
+        flags(flags),
+        width(width),
+        height(height),
+        unaligned_width(uw),
+        unaligned_height(uh),
+        format(format),
+        buffer_type(buf_type),
+        layer_count(1),
+        id(0),
+        usage(usage),
+        size(size),
+        offset(0),
+        offset_metadata(0),
+        base(0),
+        base_metadata(0),
+        gpuaddr(0) {
+
+    version = static_cast<int>(sizeof(native_handle));
+    numInts = NumInts();
+    numFds = kNumFds;
+  }
+#endif

--- a/gralloc/gr_priv_handle.h
+++ b/gralloc/gr_priv_handle.h
@@ -82,66 +82,11 @@ struct private_handle_t {
   int unaligned_height;  // holds height client asked to allocate
   int format;
   int buffer_type;
-#ifndef USE_GRALLOC1
-  unsigned int layer_count;
-  uint64_t id;
-  uint64_t usage;
-#endif
 
-  unsigned int size;
-  unsigned int offset;
-  unsigned int offset_metadata;
-  uint64_t base;
-  uint64_t base_metadata;
-  uint64_t gpuaddr;
-#ifdef USE_GRALLOC1
-  unsigned int layer_count;
-  uint64_t id;
-  uint64_t usage;
-#endif
+  // Target-specific members
+#include <private_handle_members.h>
+
 #ifdef __cplusplus
-  static const int kNumFds = 2;
-  static const int kMagic = 'gmsm';
-
-  static inline int NumInts() {
-    return ((sizeof(private_handle_t) - sizeof(native_handle_t)) / sizeof(int)) - kNumFds;
-  }
-
-  private_handle_t(int fd, int meta_fd, int flags, int width, int height, int uw, int uh,
-                   int format, int buf_type, unsigned int size, uint64_t usage = 0)
-      : fd(fd),
-        fd_metadata(meta_fd),
-        magic(kMagic),
-        flags(flags),
-        width(width),
-        height(height),
-        unaligned_width(uw),
-        unaligned_height(uh),
-        format(format),
-        buffer_type(buf_type),
-#ifndef USE_GRALLOC1
-        layer_count(1),
-        id(0),
-        usage(usage),
-#endif
-        size(size),
-        offset(0),
-        offset_metadata(0),
-        base(0),
-        base_metadata(0),
-#ifdef USE_GRALLOC1
-        gpuaddr(0),
-        layer_count(1),
-        id(0),
-        usage(usage) {
-#else
-        gpuaddr(0) {
-#endif
-    version = static_cast<int>(sizeof(native_handle));
-    numInts = NumInts();
-    numFds = kNumFds;
-  }
-
   // Legacy constructor used by some clients
   private_handle_t(int fd, unsigned int size, int usage, int buf_type, int format, int w, int h)
       : private_handle_t(fd, -1, PRIV_FLAGS_CLIENT_ALLOCATED, w, h, 0, 0, format, buf_type, size,

--- a/gralloc/gr_priv_handle.h
+++ b/gralloc/gr_priv_handle.h
@@ -82,9 +82,11 @@ struct private_handle_t {
   int unaligned_height;  // holds height client asked to allocate
   int format;
   int buffer_type;
+#ifndef USE_GRALLOC1
   unsigned int layer_count;
   uint64_t id;
   uint64_t usage;
+#endif
 
   unsigned int size;
   unsigned int offset;
@@ -92,6 +94,11 @@ struct private_handle_t {
   uint64_t base;
   uint64_t base_metadata;
   uint64_t gpuaddr;
+#ifdef USE_GRALLOC1
+  unsigned int layer_count;
+  uint64_t id;
+  uint64_t usage;
+#endif
 #ifdef __cplusplus
   static const int kNumFds = 2;
   static const int kMagic = 'gmsm';
@@ -112,15 +119,24 @@ struct private_handle_t {
         unaligned_height(uh),
         format(format),
         buffer_type(buf_type),
+#ifndef USE_GRALLOC1
         layer_count(1),
         id(0),
         usage(usage),
+#endif
         size(size),
         offset(0),
         offset_metadata(0),
         base(0),
         base_metadata(0),
+#ifdef USE_GRALLOC1
+        gpuaddr(0),
+        layer_count(1),
+        id(0),
+        usage(usage) {
+#else
         gpuaddr(0) {
+#endif
     version = static_cast<int>(sizeof(native_handle));
     numInts = NumInts();
     numFds = kNumFds;

--- a/gralloc1/private_handle_members.h
+++ b/gralloc1/private_handle_members.h
@@ -1,0 +1,45 @@
+  unsigned int size;
+  unsigned int offset;
+  unsigned int offset_metadata;
+  uint64_t base;
+  uint64_t base_metadata;
+  uint64_t gpuaddr;
+
+  unsigned int layer_count;
+  uint64_t id;
+  uint64_t usage;
+
+#ifdef __cplusplus
+  static const int kNumFds = 2;
+  static const int kMagic = 'gmsm';
+
+  static inline int NumInts() {
+    return ((sizeof(private_handle_t) - sizeof(native_handle_t)) / sizeof(int)) - kNumFds;
+  }
+
+  private_handle_t(int fd, int meta_fd, int flags, int width, int height, int uw, int uh,
+                   int format, int buf_type, unsigned int size, uint64_t usage = 0)
+      : fd(fd),
+        fd_metadata(meta_fd),
+        magic(kMagic),
+        flags(flags),
+        width(width),
+        height(height),
+        unaligned_width(uw),
+        unaligned_height(uh),
+        format(format),
+        buffer_type(buf_type),
+        size(size),
+        offset(0),
+        offset_metadata(0),
+        base(0),
+        base_metadata(0),
+        gpuaddr(0),
+        layer_count(1),
+        id(0),
+        usage(usage) {
+    version = static_cast<int>(sizeof(native_handle));
+    numInts = NumInts();
+    numFds = kNumFds;
+  }
+#endif

--- a/gralloc_defaults.go
+++ b/gralloc_defaults.go
@@ -22,13 +22,15 @@ func grallocDefaultsFactory() android.Module {
 func grallocDefaults(ctx android.LoadHookContext) {
 	gralloc1 := ctx.Config().VendorConfig("gralloc").Bool("use_v1")
 
-	if gralloc1 {
-		p := struct {
-			Cflags []string
-		}{
-			[]string{"-DUSE_GRALLOC1"},
-		}
+	p := struct {
+		Export_include_dirs []string
+	}{}
 
-		ctx.AppendProperties(&p)
+	if gralloc1 {
+		p.Export_include_dirs = []string{"gralloc1"}
+	} else {
+		p.Export_include_dirs = []string{"gralloc-next"}
 	}
+
+	ctx.AppendProperties(&p)
 }

--- a/gralloc_defaults.go
+++ b/gralloc_defaults.go
@@ -1,0 +1,34 @@
+package gralloc
+
+import (
+	"android/soong/android"
+	"android/soong/cc"
+)
+
+func init() {
+	// Register our own module type
+	android.RegisterModuleType("gralloc_defaults", grallocDefaultsFactory)
+}
+
+func grallocDefaultsFactory() android.Module {
+	module := cc.DefaultsFactory()
+
+	// When the module is loaded, execute grallocDefaults
+	android.AddLoadHook(module, grallocDefaults)
+
+	return module
+}
+
+func grallocDefaults(ctx android.LoadHookContext) {
+	gralloc1 := ctx.Config().VendorConfig("gralloc").Bool("use_v1")
+
+	if gralloc1 {
+		p := struct {
+			Cflags []string
+		}{
+			[]string{"-DUSE_GRALLOC1"},
+		}
+
+		ctx.AppendProperties(&p)
+	}
+}


### PR DESCRIPTION
Add gralloc1 fallback to the 8.1 branch, using the same mechanism previously invented for 7.1.