### PR TITLE
[R/Q] android.bp: Remove libhidltransport from shared libs

### DIFF
--- a/libdisplayconfig/Android.bp
+++ b/libdisplayconfig/Android.bp
@@ -8,7 +8,6 @@ cc_library_shared {
     ],
     shared_libs: [
         "libhidlbase",
-        "libhidltransport",
         "libutils",
         "vendor.display.config@1.0",
         "vendor.display.config@1.4"


### PR DESCRIPTION
In Android R libhidltransport is no longer available to use.
Thus remove this library.