### PR TITLE
qdMetadata: Remove unused metadata types

### DIFF
--- a/libqdmetadata/qdMetaData.cpp
+++ b/libqdmetadata/qdMetaData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,6 +38,61 @@
 
 #include <cinttypes>
 
+static int colorMetaDataToColorSpace(ColorMetaData in, ColorSpace_t *out) {
+  if (in.colorPrimaries == ColorPrimaries_BT601_6_525 ||
+      in.colorPrimaries == ColorPrimaries_BT601_6_625) {
+    if (in.range == Range_Full) {
+      *out = ITU_R_601_FR;
+    } else {
+      *out = ITU_R_601;
+    }
+  } else if (in.colorPrimaries == ColorPrimaries_BT2020) {
+    if (in.range == Range_Full) {
+      *out = ITU_R_2020_FR;
+    } else {
+      *out = ITU_R_2020;
+    }
+  } else if (in.colorPrimaries == ColorPrimaries_BT709_5) {
+    *out = ITU_R_709;
+  } else {
+    ALOGE("Cannot convert ColorMetaData to ColorSpace_t");
+    return -1;
+  }
+
+  return 0;
+}
+
+static int colorSpaceToColorMetadata(ColorSpace_t in, ColorMetaData *out) {
+  out->transfer = Transfer_sRGB;
+  switch (in) {
+    case ITU_R_601:
+      out->colorPrimaries = ColorPrimaries_BT601_6_525;
+      out->range = Range_Limited;
+      break;
+    case ITU_R_601_FR:
+      out->colorPrimaries = ColorPrimaries_BT601_6_525;
+      out->range = Range_Full;
+      break;
+    case ITU_R_709:
+      out->colorPrimaries = ColorPrimaries_BT709_5;
+      out->range = Range_Limited;
+      break;
+    case ITU_R_2020:
+      out->colorPrimaries = ColorPrimaries_BT2020;
+      out->range = Range_Limited;
+      break;
+    case ITU_R_2020_FR:
+      out->colorPrimaries = ColorPrimaries_BT2020;
+      out->range = Range_Full;
+      break;
+    default:
+      ALOGE("Cannot convert ColorSpace_t to ColorMetaData");
+      return -1;
+      break;
+  }
+
+  return 0;
+}
 unsigned long getMetaDataSize() {
     return static_cast<unsigned long>(ROUND_UP_PAGESIZE(sizeof(MetaData_t)));
 }
@@ -107,9 +162,13 @@ int setMetaDataVa(MetaData_t *data, DispParamType paramType,
         case UPDATE_REFRESH_RATE:
             data->refreshrate = *((float *)param);
             break;
-        case UPDATE_COLOR_SPACE:
-            data->colorSpace = *((ColorSpace_t *)param);
-            break;
+        case UPDATE_COLOR_SPACE: {
+          ColorMetaData color;
+          if (!colorSpaceToColorMetadata(*((ColorSpace_t *)param), &color)) {
+            data->color = color;
+          }
+          break;
+        }
         case MAP_SECURE_BUFFER:
             data->mapSecureBuffer = *((int32_t *)param);
             break;
@@ -119,14 +178,8 @@ int setMetaDataVa(MetaData_t *data, DispParamType paramType,
         case LINEAR_FORMAT:
             data->linearFormat = *((uint32_t *)param);
             break;
-        case SET_IGC:
-            data->igc = *((IGC_t *)param);
-            break;
         case SET_SINGLE_BUFFER_MODE:
             data->isSingleBufferMode = *((uint32_t *)param);
-            break;
-        case SET_S3D_COMP:
-            data->s3dComp = *((S3DGpuComp_t *)param);
             break;
         case SET_VT_TIMESTAMP:
             data->vtTimeStamp = *((uint64_t *)param);
@@ -210,10 +263,6 @@ int clearMetaDataVa(MetaData_t *data, DispParamType paramType) {
         return -EINVAL;
     data->operation &= ~paramType;
     switch (paramType) {
-        case SET_S3D_COMP:
-            data->s3dComp.displayId = -1;
-            data->s3dComp.s3dMode = 0;
-            break;
         case SET_VIDEO_PERF_MODE:
             data->isVideoPerfMode = 0;
             break;
@@ -269,7 +318,10 @@ int getMetaDataVa(MetaData_t *data, DispFetchParamType paramType,
             break;
         case GET_COLOR_SPACE:
             if (data->operation & UPDATE_COLOR_SPACE) {
-                *((ColorSpace_t *)param) = data->colorSpace;
+              ColorSpace_t color_space;
+              if (!colorMetaDataToColorSpace(data->color, &color_space)) {
+                *((ColorSpace_t *)param) = color_space;
+              }
                 ret = 0;
             }
             break;
@@ -291,21 +343,9 @@ int getMetaDataVa(MetaData_t *data, DispFetchParamType paramType,
                 ret = 0;
             }
             break;
-        case GET_IGC:
-            if (data->operation & SET_IGC) {
-                *((IGC_t *)param) = data->igc;
-                ret = 0;
-            }
-            break;
         case GET_SINGLE_BUFFER_MODE:
             if (data->operation & SET_SINGLE_BUFFER_MODE) {
                 *((uint32_t *)param) = data->isSingleBufferMode;
-                ret = 0;
-            }
-            break;
-        case GET_S3D_COMP:
-            if (data->operation & SET_S3D_COMP) {
-                *((S3DGpuComp_t *)param) = data->s3dComp;
                 ret = 0;
             }
             break;

--- a/libqdmetadata/qdMetaData.h
+++ b/libqdmetadata/qdMetaData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -30,38 +30,130 @@
 #ifndef _QDMETADATA_H
 #define _QDMETADATA_H
 
-#include <QtiGrallocMetadata.h>
 #include <color_metadata.h>
-
-/* TODO: This conditional include is to prevent breaking video and camera test cases using
- * MetaData_t - camxchinodedewarp.cpp, vtest_EncoderFileSource.cpp
- */
-
-#ifdef __cplusplus
-#include <QtiGrallocPriv.h>
-#endif
-
-#ifndef __QTI_DISPLAY_GRALLOC__
-#pragma message "qdMetaData.h is being deprecated"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct MetaData_t;
+#define MAX_UBWC_STATS_LENGTH 32
+#define GRAPHICS_METADATA_SIZE 4096
+#define CVP_METADATA_SIZE 1024
 
-enum ColorSpace_t {
-  ITU_R_601,
-  ITU_R_601_FR,
-  ITU_R_709,
-  ITU_R_2020,
-  ITU_R_2020_FR,
+enum ColorSpace_t{
+    ITU_R_601,
+    ITU_R_601_FR,
+    ITU_R_709,
+    ITU_R_2020,
+    ITU_R_2020_FR,
 };
 
 struct BufferDim_t {
-  int32_t sliceWidth;
-  int32_t sliceHeight;
+    int32_t sliceWidth;
+    int32_t sliceHeight;
+};
+
+enum UBWC_Version {
+    UBWC_UNUSED      = 0,
+    UBWC_1_0         = 0x1,
+    UBWC_2_0         = 0x2,
+    UBWC_3_0         = 0x3,
+    UBWC_4_0         = 0x4,
+    UBWC_MAX_VERSION = 0xFF,
+};
+
+struct UBWC_2_0_Stats {
+    uint32_t nCRStatsTile32;  /**< UBWC Stats info for  32 Byte Tile */
+    uint32_t nCRStatsTile64;  /**< UBWC Stats info for  64 Byte Tile */
+    uint32_t nCRStatsTile96;  /**< UBWC Stats info for  96 Byte Tile */
+    uint32_t nCRStatsTile128; /**< UBWC Stats info for 128 Byte Tile */
+    uint32_t nCRStatsTile160; /**< UBWC Stats info for 160 Byte Tile */
+    uint32_t nCRStatsTile192; /**< UBWC Stats info for 192 Byte Tile */
+    uint32_t nCRStatsTile256; /**< UBWC Stats info for 256 Byte Tile */
+};
+
+struct UBWCStats {
+    enum UBWC_Version version; /* Union depends on this version. */
+    uint8_t bDataValid;      /* If [non-zero], CR Stats data is valid.
+                               * Consumers may use stats data.
+                               * If [zero], CR Stats data is invalid.
+                               * Consumers *Shall* not use stats data */
+    union {
+        struct UBWC_2_0_Stats ubwc_stats;
+        uint32_t reserved[MAX_UBWC_STATS_LENGTH]; /* This is for future */
+    };
+};
+
+typedef struct GraphicsMetadata {
+    uint32_t size;
+    uint32_t data[GRAPHICS_METADATA_SIZE];
+} GraphicsMetadata;
+
+#define VIDEO_HISTOGRAM_STATS_SIZE (4 * 1024)
+/* Frame type bit mask */
+#define QD_SYNC_FRAME (0x1 << 0)
+struct VideoHistogramMetadata {
+    uint32_t stats_info[1024]; /* video stats payload */
+    uint32_t stat_len; /* Payload size in bytes */
+    uint32_t frame_type; /* bit mask to indicate frame type */
+    uint32_t display_width;
+    uint32_t display_height;
+    uint32_t decode_width;
+    uint32_t decode_height;
+    uint32_t reserved[12];
+};
+
+typedef struct CVPMetadata {
+    uint32_t size; /* payload size in bytes */
+    uint8_t payload[CVP_METADATA_SIZE];
+} CVPMetadata;
+
+struct MetaData_t {
+    int32_t operation;
+    int32_t interlaced;
+    struct BufferDim_t bufferDim;
+    float refreshrate;
+     /* Gralloc sets PRIV_SECURE_BUFFER flag to inform that the buffers are from
+      * ION_SECURE. which should not be mapped. However, for GPU post proc
+      * feature, GFX needs to map this buffer, in the client context and in SF
+      * context, it should not. Hence to differentiate, add this metadata field
+      * for clients to set, and GPU will to read and know when to map the
+      * SECURE_BUFFER(ION) */
+    int32_t mapSecureBuffer;
+    /* The supported formats are defined in gralloc_priv.h to
+     * support legacy code*/
+    uint32_t s3dFormat;
+    /* VENUS output buffer is linear for UBWC Interlaced video */
+    uint32_t linearFormat;
+    /* Set by graphics to indicate that this buffer will be written to but not
+     * swapped out */
+    uint32_t isSingleBufferMode;
+
+    /* Set by camera to program the VT Timestamp */
+    uint64_t vtTimeStamp;
+    /* Color Aspects + HDR info */
+    ColorMetaData color;
+    /* Consumer should read this data as follows based on
+     * Gralloc flag "interlaced" listed above.
+     * [0] : If it is progressive.
+     * [0] : Top field, if it is interlaced.
+     * [1] : Do not read, if it is progressive.
+     * [1] : Bottom field, if it is interlaced.
+     */
+    struct UBWCStats ubwcCRStats[2];
+    /* Set by camera to indicate that this buffer will be used for a High
+     * Performance Video Usecase */
+    uint32_t isVideoPerfMode;
+    /* Populated and used by adreno during buffer size calculation.
+     * Set only for RGB formats. */
+    GraphicsMetadata graphics_metadata;
+    /* Video hisogram stats populated by video decoder */
+    struct VideoHistogramMetadata video_histogram_stats;
+    /*
+     * Producer (camera) will set cvp metadata and consumer (video) will
+     * use it. The format of metadata is known to producer and consumer.
+     */
+    CVPMetadata cvpMetadata;
 };
 
 enum DispParamType {
@@ -105,9 +197,6 @@ enum DispFetchParamType {
     GET_CVP_METADATA          = 0x00010000,
     GET_VIDEO_HISTOGRAM_STATS = 0x00020000
 };
-
-/* Frame type bit mask */
-#define QD_SYNC_FRAME (0x1 << 0)
 
 struct private_handle_t;
 int setMetaData(struct private_handle_t *handle, enum DispParamType paramType,


### PR DESCRIPTION
This change removes metadata types which are not set. The color
space is also set through ColorMetadata, with helpers to convert
to/from the legacy type ColorSpace_t.