### PR TITLE
[8.1] [1/5] Android.bp: Wrap BluePrint targets in a soong namespace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,6 @@
+soong_namespace {
+}
+
 bootstrap_go_package {
     name: "soong-gralloc_defaults",
     pkgPath: "vendor/qcom/opensource/display-commonsys-intf",


### PR DESCRIPTION
In order to have two display stacks live concurrently in the same tree - exposing the same targets - they need to be hidden behind a namespace that's either explicitly included by another namespace (display specifies the SM8150/SM8250 namespace to include) or exposed to `make` through `PRODUCT_SOONG_NAMESPACES`.
